### PR TITLE
Generic solution for pre/post start/stop scripts 

### DIFF
--- a/deployer/contrib/services/upstart.py
+++ b/deployer/contrib/services/upstart.py
@@ -78,11 +78,13 @@ class UpstartService(Service):
                 pre_start_script = pre_start_script_template % {
                         'content': indent(self.pre_start_script),
                     }
+            else:
+                pre_start_script = ''
+
             if self.post_stop_script:
                 post_stop_script = post_stop_script_template % {
                         'content': indent(self.post_stop_script),
                     }
-
             else:
                 post_stop_script = ''
 


### PR DESCRIPTION
I could probably even remove the empty strings and test with `getattr` to see whether a service implemented them, but explicit is better than implicit, no?
