### PR TITLE
Add include_isolations to get_subservices

### DIFF
--- a/deployer/service.py
+++ b/deployer/service.py
@@ -530,8 +530,8 @@ class Env(object):
     def __call__(self, *a, **kw):
         self._service(*a, **kw).run(self._pty, self._logger)
 
-    def get_subservices(self):
-        for name, subservice in self._service.get_subservices():
+    def get_subservices(self, include_isolations=True):
+        for name, subservice in self._service.get_subservices(include_isolations):
             yield name, self.get_subservice(name)
 
     def get_group(self):
@@ -1129,7 +1129,7 @@ class Service(object):
             if not name.startswith('_') and isinstance(member, Action) and not getattr(self, name).is_property:
                 yield name, getattr(self, name)
 
-    def get_subservices(self):
+    def get_subservices(self, include_isolations=True):
         """
         Yield the available nested subservices. Returns tupels of (name, subservice_instance)
         (Except the private ones)
@@ -1143,7 +1143,8 @@ class Service(object):
                     yield name, getattr(self, name)
 
         # Isolations also act as subservices.
-        if self.Meta.isolate_role and not self._is_isolated:
+        if include_isolations and \
+                self.Meta.isolate_role and not self._is_isolated:
             for i in get_isolations(self):
                 yield ':%s' % i.name, i.service
 


### PR DESCRIPTION
Missing parameter for the `walk_services` command. I don't know whether we want to push this option up to `walk_services` too? It could be useful to have the isolations too, but I want to make sure we don't iterate over them twice in `map_services`.
