### PR TITLE
Django execute_code command

### DIFF
--- a/deployer/contrib/services/django.py
+++ b/deployer/contrib/services/django.py
@@ -147,6 +147,8 @@ class Django(Service):
     def wsgi_app_location(self):
         return '/etc/wsgi-apps/%s.py' % self.slug
 
+    def execute_code(self, code):
+        self.hosts.run(self._get_management_command('shell --plain') + " <<__HEREDOC__\n" + code + "\n__HEREDOC__")
 
     # ===========[ WSGI setup ]============
 


### PR DESCRIPTION
Pipe Python code via heredoc to Django shell. Crude, but it works. `--plain` always uses the regular Python instead of IPython, this gives us consistency over all servers.
