### PR TITLE
check if interface is defined in the host

### DIFF
--- a/deployer/host/base.py
+++ b/deployer/host/base.py
@@ -264,6 +264,8 @@ class Host(object):
         """
         # We add "cd /", to be sure that at least no error get thrown because
         # we're in a non existing directory right now.
+        if hasattr(self, 'interface'):
+            interface = self.interface
 
         return self._run_silent(
                 """cd /; /sbin/ifconfig "%s" | grep 'inet ad' | """


### PR DESCRIPTION
Allow to define the network interface to select the ip in the host definition.
{{{
class xxx(SSHHost):
    ...
    interface = 'eth1'
    ...
}}}
