### PR TITLE
docs: Fix a few typos

### DIFF
--- a/deployer/console.py
+++ b/deployer/console.py
@@ -4,7 +4,7 @@ The ``console`` object is an interface for user interaction from within a
 input.
 
 It has output methods that take the terminal size into account, like pagination
-and multi-column display. It takes care of the pseudo terminal underneat.
+and multi-column display. It takes care of the pseudo terminal underneath.
 
 Example:
 

--- a/deployer/host/base.py
+++ b/deployer/host/base.py
@@ -205,7 +205,7 @@ class Host(object):
     def copy(self, pty=None):
         """
         Create a deep copy of this Host class.
-        (the pty-parameter allows to bind it to anothor pty)
+        (the pty-parameter allows to bind it to another pty)
         """
         h = self.__class__(pty=(pty or self.pty), logger=self.logger)
         h.host_context = self.host_context.copy()
@@ -385,7 +385,7 @@ class Host(object):
 
             # Execute
             if use_sudo:
-                # We use 'sudo su' instead of 'sudo -u', because shell expension
+                # We use 'sudo su' instead of 'sudo -u', because shell expansion
                 # of ~ is threated differently. e.g.
                 #
                 # 1. This will still show the home directory of the original user

--- a/deployer/host/local.py
+++ b/deployer/host/local.py
@@ -27,7 +27,7 @@ _localhost_start_path = os.getcwd()
 class LocalHost(Host):
     """
     ``LocalHost`` can be used instead of :class:`SSHHost` for local execution.
-    It uses ``pexpect`` underneat.
+    It uses ``pexpect`` underneath.
     """
     slug = 'localhost'
     address = 'localhost'

--- a/deployer/node/decorators.py
+++ b/deployer/node/decorators.py
@@ -18,9 +18,9 @@ def suppress_action_result(action):
 
 def dont_isolate_yet(func):
     """
-    If the node has not yet been separated in serveral parallel, isolated
+    If the node has not yet been separated in several parallel, isolated
     nodes per host. Don't do it yet for this function.
-    When anothor action of the same host without this decorator is called,
+    When another action of the same host without this decorator is called,
     the node will be split.
 
     It's for instance useful for reading input, which is similar for all

--- a/deployer/run/socket_server.py
+++ b/deployer/run/socket_server.py
@@ -184,7 +184,7 @@ class Connection(object):
         stdin = os.fdopen(self.slave, 'r', 0)
         stdout = os.fdopen(self.slave, 'w', 0)
 
-        # Create pty object, for passing to deployment enviroment.
+        # Create pty object, for passing to deployment environment.
         self.pty = SocketPty(stdin, stdout, self.runInNewPtys,
                     interactive=protocol.factory.interactive)
 

--- a/deployer/run/telnet_server.py
+++ b/deployer/run/telnet_server.py
@@ -147,7 +147,7 @@ class Session(object):
         # File descriptors for slave pty.
         stdin = stdout = os.fdopen(self.slave, 'r+w', 0)
 
-        # Create pty object, for passing to deployment enviroment.
+        # Create pty object, for passing to deployment environment.
         self.pty = Pty(stdin, stdout)
 
     def start(self):

--- a/deployer/utils/string_utils.py
+++ b/deployer/utils/string_utils.py
@@ -16,7 +16,7 @@ def esc1(string):
     """
     Escape single quotes, mainly for use in shell commands. Single quotes
     are usually preferred above double quotes, because they never do shell
-    expension inside. e.g.
+    expansion inside. e.g.
 
     ::
 

--- a/docs/pages/architecture_of_roles_and_nodes.rst
+++ b/docs/pages/architecture_of_roles_and_nodes.rst
@@ -10,7 +10,7 @@ Use cases
 ---------
 
 Before we go in depth, let's first look at a typical set-up of a web server.
-The following picture displays serveral connected components. It contains a web
+The following picture displays several connected components. It contains a web
 server connected to some database back-ends, and a load balancer in front of
 it. Every component appears exactly once.
 

--- a/docs/pages/django-deployment.rst
+++ b/docs/pages/django-deployment.rst
@@ -127,7 +127,7 @@ Probably obvious, we have a clone and checkout function that are meant to go
 to a certain directory on the server and run a shell command in there through
 :func:`~deployer.host.base.Host.run`. Some points worth noting:
 
-- ``expand=True``: this means that we should do tilde-expension. You want the
+- ``expand=True``: this means that we should do tilde-expansion. You want the
   tilde to be replaced with the home directory. If you have an absolute path,
   this isn't necessary.
 - :func:`~deployer.utils.string_utils.esc1`: This is important to avoid shell

--- a/docs/pages/internals.rst
+++ b/docs/pages/internals.rst
@@ -5,7 +5,7 @@ Internals
 
 This page will try to give a high level overview of how the framework is
 working. While the end-user of the framework won't usually touch much more than
-the ``Node`` and ``Host`` classes, there's a lot more going on underneat.
+the ``Node`` and ``Host`` classes, there's a lot more going on underneath.
 
 There's a lot of meta-programming, some domain specific languages, and a
 mix of event-driven and blocking code.
@@ -14,7 +14,7 @@ mix of event-driven and blocking code.
 Data flow
 ----------
 
-Roughly, this is the current flow from the interactive shell untill the actual
+Roughly, this is the current flow from the interactive shell until the actual
 SSH client.
 
 .. graphviz::


### PR DESCRIPTION
There are small typos in:
- deployer/console.py
- deployer/host/base.py
- deployer/host/local.py
- deployer/node/decorators.py
- deployer/run/socket_server.py
- deployer/run/telnet_server.py
- deployer/utils/string_utils.py
- docs/pages/architecture_of_roles_and_nodes.rst
- docs/pages/django-deployment.rst
- docs/pages/internals.rst

Fixes:
- Should read `underneath` rather than `underneat`.
- Should read `expansion` rather than `expension`.
- Should read `several` rather than `serveral`.
- Should read `environment` rather than `enviroment`.
- Should read `another` rather than `anothor`.
- Should read `until` rather than `untill`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md